### PR TITLE
Initial support for explain command

### DIFF
--- a/src/roadctl/cmd/describe.go
+++ b/src/roadctl/cmd/describe.go
@@ -65,7 +65,7 @@ func runDescribe(cmd *cobra.Command, args []string) {
 
 	for _, r := range replies {
 		//Hack until all assets return a Response type
-    // fmtFlag is just "f" if not specified
+		// fmtFlag is just "f" if not specified
 		if r != nil {
 			switch strings.ToLower(fmtFlag) {
 			case "text":
@@ -77,7 +77,7 @@ func runDescribe(cmd *cobra.Command, args []string) {
 			case "json":
 				r.RespondWithJSON()
 				break
-      default:
+			default:
 				r.RespondWithText()
 			}
 		}

--- a/src/roadctl/cmd/responses.go
+++ b/src/roadctl/cmd/responses.go
@@ -17,7 +17,6 @@ response: defines mandatory response methods a resource MUST implement
   RespondWithText:
   RespondWithYAML:
   RespondWithJSON:
-  TODO: define option flags to control output formatting
 */
 package cmd
 

--- a/src/roadctl/roadctl.go
+++ b/src/roadctl/roadctl.go
@@ -18,5 +18,5 @@ package main
 import "roadctl/cmd"
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION
Explain documents the structure of a resource

This code pulls those explanations from the docs directory inside of the templates repository.
Each resource has a corresponding resource.txt file in the docs directory.
The files are copied locally when a user runs roadctl get templates --int
