### PR TITLE
Case sensative structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION := 0.6.0
+VERSION := 0.7.0
 BUILD := $(shell git rev-parse --short HEAD)
 PROJECTNAME := $(shell basename "$(PWD)")
 PROJDIR := $(shell pwd)

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -197,6 +197,9 @@ type tplData struct {
 	SwaggerGeneratedStructs string // swagger doc and go struct
 	DumpStructs             string // Generic dump of given object type
 
+	PrimaryTableName string // Used as the structure name for
+	// Storing user data
+
 	//JSON data
 	PostJSON string // Sample data for a post
 	PutJSON  string // Sample data for a put
@@ -221,6 +224,7 @@ func tplDataMapper(defs tplDef, output *tplData) error {
 	output.DefFile = tplDefFile
 	output.OrganizationLicense = defs.Project.License
 	output.Organization = defs.Info.Organization
+	output.PrimaryTableName = defs.TableList[0].TableName
 
 	// TODO: Write an SQL safe naming function
 	output.OrgSQLSafe = strcase.ToCamel(defs.Info.Organization)
@@ -985,11 +989,10 @@ func tplReadDefinitions(definitionsStruct *tplDef) error {
 
 	errs := definitionsStruct.Validate()
 
-	if errs != nil {
+	if errs > 0 {
 		fmt.Println("definitionsStruct.Validate()")
-		for errs != nil {
-			fmt.Println(errs.Error())
-			errs = errs.nextError
+		for _, item := range ErrList {
+			fmt.Println(item.Error())
 		}
 		os.Exit(-1)
 	}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -1,0 +1,61 @@
+// Package cmd from gobra
+//   Valid JSON and Go type supported in definitions files
+//   With associated methods
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+)
+
+// mappedTypes defines valid Go types
+type mappedTypes struct {
+	validDefinitionType string // acceptable types in a definition file
+	name                string // go built in type or defined type
+	random              interface{}
+}
+
+// builtInTypes
+//
+var builtInTypes = []mappedTypes{
+	{"string", "string", RandomString(15)},
+	{"boolean", "bool", RandomBool()},
+	{"number", "int", RandomInteger(0, 254)},
+	{"int", "int", RandomInteger(0, 254)},
+	{"uint", "uint", RandomInteger(0, 254)},
+	{"byte", "byte", RandomString(1)},
+	{"rune", "byte", RandomString(1)},
+	{"float", "float", RandomFloat()},
+	{"uuid", "uuid", RandomString(44)},
+	{"time", "Time.time", time.Now().Format(time.RFC3339)},
+}
+
+func (t *mappedTypes) validInputType(key string) bool {
+	for _, input := range builtInTypes {
+		if input.validDefinitionType == key {
+			fmt.Println("Success: ", input.validDefinitionType, key)
+			return true
+		}
+	}
+	fmt.Println("Failure: ", key, " not found")
+	return false
+}
+
+func (t *mappedTypes) inputToGoType(key string) string {
+	for _, input := range builtInTypes {
+		if input.validDefinitionType == key {
+			return input.name
+		}
+	}
+	return ""
+}
+
+func (t *mappedTypes) randomGoData(key string) interface{} {
+	for _, input := range builtInTypes {
+		if input.validDefinitionType == key {
+			return input.random
+		}
+	}
+	return ""
+}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -14,27 +14,29 @@ type mappedTypes struct {
 	validDefinitionType string // acceptable types in a definition file
 	name                string // go built in type or defined type
 	random              interface{}
+	quoted              bool
 }
 
 // builtInTypes
 //
 var builtInTypes = []mappedTypes{
-	{"string", "string", RandomString(15)},
-	{"boolean", "bool", RandomBool()},
-	{"number", "int", RandomInteger(0, 254)},
-	{"int", "int", RandomInteger(0, 254)},
-	{"uint", "uint", RandomInteger(0, 254)},
-	{"byte", "byte", RandomString(1)},
-	{"rune", "byte", RandomString(1)},
-	{"float", "float", RandomFloat()},
-	{"uuid", "uuid", RandomString(44)},
-	{"time", "Time.time", time.Now().Format(time.RFC3339)},
+	{"string", "string", RandomString(15), true},
+	{"boolean", "bool", RandomBool(), false},
+	{"number", "int", RandomInteger(0, 254), false},
+	{"int", "int", RandomInteger(0, 254), false},
+	{"uint", "uint", RandomInteger(0, 254), false},
+	{"byte", "byte", RandomString(1), true},
+	{"rune", "byte", RandomString(1), true},
+	{"float", "float64", RandomFloat(), false},
+	{"float64", "float64", RandomFloat(), false},
+	{"float32", "float32", RandomFloat(), false},
+	{"uuid", "string", RandomUUID(), true},
+	{"time", "time.Time", time.Now().Format(time.RFC3339), true},
 }
 
 func (t *mappedTypes) validInputType(key string) bool {
 	for _, input := range builtInTypes {
 		if input.validDefinitionType == key {
-			fmt.Println("Success: ", input.validDefinitionType, key)
 			return true
 		}
 	}
@@ -51,10 +53,15 @@ func (t *mappedTypes) inputToGoType(key string) string {
 	return ""
 }
 
-func (t *mappedTypes) randomGoData(key string) interface{} {
+func (t *mappedTypes) randomJSONData(key string) interface{} {
 	for _, input := range builtInTypes {
 		if input.validDefinitionType == key {
-			return input.random
+			if input.quoted {
+				v := fmt.Sprintf("\"%v\"", input.random)
+				return v
+			} else {
+				return input.random
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
extend validation and data generation logic
old logic only validated input types, not Go types or sample generated data
This logic has been moved into cmd/types.go and integrated with cmd/templates.go