### PR TITLE
Support creating lists/arrays/vectors of sub-tables

### DIFF
--- a/cmd/blueprints.go
+++ b/cmd/blueprints.go
@@ -142,6 +142,8 @@ var blueprints *template.Template
 type bpData struct {
 	// Information about company and project
 	Organization        string // Name of Organization
+	GitHubOrg           string // Orginization name in GitHub
+	SonarCloudOrg       string // Orginization name in SonarCloud
 	OrgSQLSafe          string // Mapped to a safe name for using in SQL
 	OrganazationInfo    string // Name of Organization
 	OrganizationLicense string // Org license/copyright
@@ -243,6 +245,8 @@ func bpDataMapper(defs bpDef, output *bpData) error {
 	output.DefFile = bpDefFile
 	output.OrganizationLicense = defs.Project.License
 	output.Organization = defs.Info.Organization
+	output.GitHubOrg = defs.Info.GitHubOrg
+	output.SonarCloudOrg = defs.Info.SonarCloudOrg
 	if len(defs.TableList) > 0 {
 		output.PrimaryTableName = defs.TableList[0].TableName
 	}

--- a/cmd/blueprints.go
+++ b/cmd/blueprints.go
@@ -80,6 +80,7 @@ const (
 // for full license information.
 //`
 )
+
 const strcutComment = `
 //
 //
@@ -115,6 +116,7 @@ const structField = "\t%s %s\t`%s:\"%s\"`\n"
 //  type will be the sub-table
 //  No options
 const structSubstruct = "\t%s %s\t`%s:\"%s\"`\n"
+const structSubstructList = "\t%s []%s\t`%s:\"%s\"`\n"
 
 // Makefile constants
 const (
@@ -365,6 +367,9 @@ func bpAddJSON(item bpTableItem, defs bpDef, jsonString *string) {
 		*jsonString = fmt.Sprintf(jsonObjectStart)
 	} else {
 		*jsonString += fmt.Sprintf(jsonField, strings.ToLower(item.Name))
+		if item.IsList {
+			*jsonString += fmt.Sprintf(jsonListStart)
+		}
 		*jsonString += fmt.Sprintf(jsonObjectStart)
 	}
 
@@ -390,16 +395,27 @@ func bpAddJSON(item bpTableItem, defs bpDef, jsonString *string) {
 	}
 
 	// See if there are any children
-	if len(item.Children) > 0 {
+	processed := 0
+	toProcess := len(item.Children)
+	if processed > 0 {
 		*jsonString += fmt.Sprintf(jsonSeperator)
 		// Add child tables first
 		for _, child := range item.Children {
 			bpAddJSON(*child, defs, jsonString)
+			processed += 1
 		}
 	}
 
 	// Close and append to bpData.SwaggerGeneratedStructs
 	*jsonString += jsonObjectEnd
+	if item.IsList {
+		*jsonString += fmt.Sprintf(jsonListEnd)
+	}
+
+	// If more objects or list add a comma
+	if toProcess < processed {
+		*jsonString += ","
+	}
 
 	return
 }
@@ -452,9 +468,16 @@ func bpAddStruct(item bpTableItem, defs bpDef, output *bpData) {
 			bpAddStruct(*child, defs, output)
 
 			// Same as structField except type with be the suitable
-			tableString += fmt.Sprintf(structSubstruct,
+			str := structSubstruct
+			if child.IsList {
+				str = structSubstructList
+			}
+
+			// TODO: thing about this
+			tableString += fmt.Sprintf(str,
 				strcase.ToCamel(child.Name),
-				strings.ToLower(child.Name),
+				child.Name,
+				//strcase.ToCamel(child.Name),
 				"json",
 				strings.ToLower(child.Name))
 		}
@@ -824,7 +847,7 @@ func bpCreate(rn string) (reply bpCreateResponse) {
 	var newEndPoint endpointConfig
 	if epList, err := newEndPoint.loadFromDefinitions(defs); err != nil {
 		msg := fmt.Errorf("Endpoints warning: [%v]'\n", err)
-		fmt.Println(msg)
+		log.Println(msg)
 	} else {
 		for _, ep := range epList {
 			// TODO: future support for other request routers
@@ -855,11 +878,11 @@ func bpCreate(rn string) (reply bpCreateResponse) {
 			projectBlocks.Metadata.Labels)
 
 		if err != nil {
-			fmt.Println("Error: ", err)
+			log.Println("Error: ", err)
 		}
 
 		if _, e := nb.GenerateBlock(defs); e != nil {
-			fmt.Println("Error: ", e)
+			log.Println("Error: ", e)
 		}
 	}
 
@@ -869,7 +892,7 @@ func bpCreate(rn string) (reply bpCreateResponse) {
 	// required imports
 	if loggerImports, err = b.getLoggerImports(defs); err != nil {
 		msg := fmt.Errorf("Failed loading import: [%s]\n", err)
-		fmt.Println(msg)
+		log.Println(msg)
 	}
 	importList = append(importList, loggerImports...)
 
@@ -1132,6 +1155,7 @@ func bpReadDefinitions(definitionsStruct *bpDef) error {
 	}
 
 	definitionsStruct.DefinitionFile = bpDefFile
+	definitionsStruct.DefinitionFileVersion = StaticDefinitionFileVersion
 
 	incSpinner()
 	errs := definitionsStruct.Validate()
@@ -1218,47 +1242,6 @@ func bpExplain(bpListOption string, rn string) bpExplainResponse {
 	return response
 }
 
-/* TODO: remove dead code
-// bpReadCodeFragment given a list of modules return a list of filesystem
-//   locations to read
-func bpReadCodeFragment(modules []string) (moduleTemplates []bpLocation, err error) {
-	// read/check blueprint cache
-	tc, te := NewBlueprintCache()
-	if te.errno != tcSuccess {
-		log.Fatalf("Failed to read blueprint cache, Got (%v)\n", te)
-	}
-
-	for _, m := range modules {
-		// Test the directory location
-		readPath := tc.location.Location() + "/" + m
-		if _, err := os.Stat(readPath); os.IsNotExist(err) {
-		}
-
-		f, err := os.Open(readPath)
-		if err != nil {
-			msg := fmt.Errorf("Failed to read templates: [%s]\n", readPath)
-			return nil, msg
-		}
-
-		list, err := f.Readdir(-1)
-		f.Close()
-
-		if err != nil {
-			msg := fmt.Errorf("Failed to read templates contents: [%s]\n", readPath)
-			return nil, msg
-		}
-
-		for _, fn := range list {
-			i := bpLocation{
-				Name:         fn.Name(),
-				RelativePath: readPath}
-			moduleTemplates = append(moduleTemplates, i)
-		}
-	}
-
-	return moduleTemplates, nil
-}
-*/
 // bpRead(name)
 //   read all files for the named blueprint
 //   return a slice of paths with file names

--- a/cmd/definitions.go
+++ b/cmd/definitions.go
@@ -89,6 +89,8 @@ type Info struct {
 	ID            string `yaml:"id"`
 	Name          string `yaml:"name"`
 	Organization  string `yaml:"organization"`
+	GitHubOrg     string `yaml:"githuborg"`
+	SonarCloudOrg string `yaml:"sonarcloudorg"`
 	ReleaseStatus string `yaml:"release-status"`
 	Version       string `yaml:"version"`
 }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -31,7 +31,7 @@ type bpError struct {
 // %w in new in go 1.13
 func (e *bpError) WrappedError() error {
 	_, f, l, _ := runtime.Caller(0)
-	err := fmt.Errorf("%v: %w Error(%w)\n", f, l, e.Err.Error())
+	err := fmt.Errorf("%v: %v Error(%w)\n", f, l, e.Err.Error())
 	return err
 }
 

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -164,7 +164,7 @@ func (l *Logger) getLoggerImports(defs bpDef) (imports []string, err error) {
 
 		nb := &Block{}
 		if nb, err = b.loadBlock(l.ID, l.Metadata.Labels); err != nil {
-			msg := fmt.Errorf("Loading block failed for ID[%s]: [%v]'\n", l.ID)
+			msg := fmt.Errorf("Loading block failed for ID[%s]: [%v]'\n", l.ID, err)
 			fmt.Println(msg)
 		}
 

--- a/cmd/sql_to_json.go
+++ b/cmd/sql_to_json.go
@@ -97,13 +97,19 @@ func createPostData(opt ...interface{}) (result []byte, err error) {
 }
 
 // createPut read a table for a given definitions file
-// and create sample test data in JSON format
+// and creates sample test data in JSON format
 // example, json, err := createPut(defs bpDef, postData []byte)
 func createPutData(opt ...interface{}) (result []byte, err error) {
 
 	if len(opt) != 2 {
 		ne := bpError{Type: ErrorGeneric,
 			Err: fmt.Errorf("Usage: (bpDef, JSON( are required")}
+		return nil, ne.WrappedError()
+	}
+	def, ok := opt[0].(bpDef)
+	if !ok {
+		ne := bpError{Type: ErrorGeneric,
+			Err: fmt.Errorf("Cast to bpDef for JSON failed: %v", ok)}
 		return nil, ne.WrappedError()
 	}
 
@@ -129,7 +135,10 @@ func createPutData(opt ...interface{}) (result []byte, err error) {
 			fmt.Println(err)
 		}
 
-		b := strings.Replace(string(putData), put["filmsuuid"].(string), post["filmsuuid"].(string), 1)
+		id := strings.ToLower(def.Info.Name) + "uuid"
+		b := strings.Replace(string(putData),
+			put[id].(string),
+			post[id].(string), 1)
 
 		return []byte(b), nil
 	}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -22,17 +22,27 @@ type mappedTypes struct {
 //
 var builtInTypes = []mappedTypes{
 	{"string", "string", RandomString(15), true},
+	{"[]string", "[]string", RandomString(15), true},
 	{"boolean", "bool", RandomBool(), false},
 	{"number", "int", RandomInteger(0, 254), false},
+	{"[]number", "[]int", RandomInteger(0, 254), false},
 	{"int", "int", RandomInteger(0, 254), false},
 	{"uint", "uint", RandomInteger(0, 254), false},
+	{"[]uint", "[]uint", RandomInteger(0, 254), false},
 	{"byte", "byte", RandomString(1), true},
+	{"[]byte", "[]byte", RandomString(1), true},
 	{"rune", "byte", RandomString(1), true},
+	{"[]rune", "[]byte", RandomString(1), true},
 	{"float", "float64", RandomFloat(), false},
+	{"[]float", "[]float64", RandomFloat(), false},
 	{"float64", "float64", RandomFloat(), false},
+	{"[]float64", "[]float64", RandomFloat(), false},
 	{"float32", "float32", RandomFloat(), false},
+	{"[]float32", "[]float32", RandomFloat(), false},
 	{"uuid", "string", RandomUUID(), true},
+	{"[]uuid", "[]string", RandomUUID(), true},
 	{"time", "time.Time", time.Now().Format(time.RFC3339), true},
+	{"[]time", "[]time.Time", time.Now().Format(time.RFC3339), true},
 }
 
 func (t *mappedTypes) validInputType(key string) bool {


### PR DESCRIPTION
- Subtables are just Go type.  So this just supports have a list of the
- Extend generated JSON data to also include arrays of objects where the objects are a Go type
specified type
- Start adding versions to definitions files

```go
// swagger:response films
type films struct {
    // FilmsUUID into JSONB

    FilmsUUID string     `json:"filmsuuid"`
    Metadata  []metadata `json:"metadata"`
    // Id
    Id string `json:"id"`
    // Title
    Title string `json:"title"`
    // Updated
    Updated time.Time `json:"updated"`
    // Created
    Created time.Time `json:"created"`
}

Example JSON
```json
{ 
  "filmsuuid": "3dbeef9e-52fe-4450-85e6-7a414502f55a",
  "id": "2o9DPl9zFi7rruS",
  "title": "2o9DPl9zFi7rruS",
  "updated": "2021-07-08T15:37:49-10:00",
  "created": "2021-07-08T15:37:49-10:00",
  "metadata": [
    {
      "author": "2o9DPl9zFi7rruS",
      "genre": "2o9DPl9zFi7rruS",
      "rating": "2o9DPl9zFi7rruS"
    }
  ]
}

```
```