### PR TITLE
Fix errors in SQL generation and harden use of --blueprints option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION := v1.1.0alpha
+VERSION := v1.2.2alpha
 BUILD := $(shell git rev-parse --short HEAD)
 PROJECTNAME := $(shell basename "$(PWD)")
 PROJDIR := $(shell pwd)

--- a/cmd/blocks.go
+++ b/cmd/blocks.go
@@ -47,7 +47,7 @@ type Block struct {
 	Metadata Metadata `yaml:"metadata"`
 
 	// Inverted namespace ID unique to these templates
-	// For example, io.pavedroard.core.loggers.http_access
+	// For example, io.pavedroad.core.loggers.http_access
 	ID string `yaml:"id"`
 
 	// Family friendly name for this grouping of templates
@@ -240,7 +240,7 @@ func (b *Block) loadBlock(ID string, labels []string) (block *Block, err error) 
 
 	// TODO: fix this hack
 	switch ID {
-	case "io.pavedroard.core.loggers.application":
+	case "io.pavedroad.core.loggers.application":
 		b = &PRApplicationLogger
 		break
 	}

--- a/cmd/blueprints.go
+++ b/cmd/blueprints.go
@@ -181,6 +181,10 @@ type bpData struct {
 	// Returns API documentation in Swagger syntax
 	Explain string
 
+	// HTTP configuration
+	HTTPHost string
+	HTTPPort string
+
 	// Integration's
 	Badges            string // badges to include docs
 	SonarKey          string
@@ -211,11 +215,15 @@ type bpData struct {
 	SwaggerGeneratedStructs string // swagger doc and go struct
 	DumpStructs             string // Generic dump of given object type
 
-	// Endpoints blueprint specific
+	// Endpoints blueprint specific generated from templates
 	EndpointRoutes   string // Holds gorilla routes to function initialization
 	EndpointHandlers string // Holds methods for each route
 	EndpointHooks    string // Generated pre/post hook functions for selected methods
 	EndpointHeaders  string // List of additional headers to set on replies
+
+	// Simple mapping
+	EndpointPort string // Port to listen on
+	EndpointHost string // Host to listen on
 
 	PrimaryTableName string // Used as the structure name for
 	// Storing user data
@@ -273,6 +281,30 @@ func bpDataMapper(defs bpDef, output *bpData) error {
 	output.Readiness = defs.Project.Kubernetes.Readiness
 	output.Metrics = defs.Project.Kubernetes.Metrics
 	output.Management = defs.Project.Kubernetes.Management
+
+	// TODO: 21/09/14:15:jscharber (refactor) Don't assume an endpoint is defined
+	if len(defs.Project.Endpoints) > 0 {
+		if defs.Project.Endpoints[0].Port != "" {
+			output.EndpointPort = defs.Project.Endpoints[0].Port
+		} else {
+			output.EndpointPort = "8081"
+		}
+		if defs.Project.Endpoints[0].Host != "" {
+			output.EndpointHost = defs.Project.Endpoints[0].Host
+		} else {
+			output.EndpointHost = "0.0.0.0"
+		}
+	}
+
+	output.HTTPHost = "0.0.0.0"
+	output.HTTPPort = "8081"
+	if defs.Project.Config.HTTPHost != "" {
+		output.HTTPHost = defs.Project.Config.HTTPHost
+	}
+
+	if defs.Project.Config.HTTPPort != "" {
+		output.HTTPPort = defs.Project.Config.HTTPPort
+	}
 
 	// CI integrations
 

--- a/cmd/definitions.go
+++ b/cmd/definitions.go
@@ -266,8 +266,8 @@ type Project struct {
 }
 
 type Config struct {
-	HTTPHost string `host:"http-host"`
-	HTTPPort string `port:"http-port"`
+	HTTPHost string `yaml:"http-host"`
+	HTTPPort string `yaml:"http-port"`
 }
 type Go struct {
 	DependencyManager string `yaml:"dependency-manager"`

--- a/cmd/definitions.go
+++ b/cmd/definitions.go
@@ -213,14 +213,33 @@ type queryParm struct {
 }
 
 type httpMethod struct {
-	Method string      `json:"method"`
-	QP     []queryParm `json:"qp"`
+	// Method HTTP method
+	Method string `json:"method"`
+
+	// QP query parameters
+	QP []queryParm `json:"qp"`
+
+	// Headers Method specific headers
+	Headers []HTTPHeader `yaml:"headers"`
 }
 
 // Endpoints
 type endPoint struct {
-	Name    string       `json:"name"`
-	Methods []httpMethod `json:"methods"`
+
+	// Name for this endpoint
+	Name string `yaml:"name"`
+
+	// Methods list of HTTP methods
+	Methods []httpMethod `yaml:"methods"`
+
+	// Headers endpoint specific headers
+	Headers []HTTPHeader `yaml:"headers"`
+}
+
+// HTTPHeader header name and value
+type HTTPHeader struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 // Project information

--- a/cmd/definitions.go
+++ b/cmd/definitions.go
@@ -234,6 +234,12 @@ type endPoint struct {
 
 	// Headers endpoint specific headers
 	Headers []HTTPHeader `yaml:"headers"`
+
+	// Port to listen on
+	Port string `yaml:"port"`
+
+	// Host address to listen on
+	Host string `yaml:"host"`
 }
 
 // HTTPHeader header name and value
@@ -256,8 +262,13 @@ type Project struct {
 	Endpoints     []endPoint     `yaml:"endpoints"`
 	Loggers       []Logger       `yaml:"loggers"`
 	Blocks        []Block        `yaml:"blocks"`
+	Config        Config         `yaml:"configuration"`
 }
 
+type Config struct {
+	HTTPHost string `host:"http-host"`
+	HTTPPort string `port:"http-port"`
+}
 type Go struct {
 	DependencyManager string `yaml:"dependency-manager"`
 }

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -90,13 +91,13 @@ func (hc *endpointConfig) GenerateBlock(block Block, bpInput bpData) (configFrag
 	for _, m := range hc.Methods {
 
 		if found, fragement := findHTTPTemplate(m, block); found {
-			//			fmt.Printf("Loading block: %s:%s\n", m, fragement.FileName)
 			tplName := block.BaseDirectory + fragement.Template.FileName
 
 			if fragement.Template.TemplatePtr == nil {
 				var def bpDef
 				if tpl, err := loadTemplate(tplName, block.Family, def, fragement.Template.TemplateFunction); err != nil {
 					msg := fmt.Errorf("File not found: [%s][%v'\n", tplName, err)
+					log.Println(msg)
 					return nil, msg
 				} else {
 					fragement.Template.TemplatePtr = tpl
@@ -110,11 +111,14 @@ func (hc *endpointConfig) GenerateBlock(block Block, bpInput bpData) (configFrag
 				Method:       m,
 				NameExported: bpInput.NameExported,
 			}
+
 			e := fragement.Template.TemplatePtr.ExecuteTemplate(&b, fragement.Template.FileName, &tplData)
 			if e != nil {
 				msg := fmt.Errorf("template execution failed : [%s][%v]", tplName, e)
+				log.Println(msg)
 				return nil, msg
 			}
+
 			configFragments.WriteString(b.String())
 		}
 	}

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -31,7 +31,7 @@ type bpError struct {
 // %w in new in go 1.13
 func (e *bpError) WrappedError() error {
 	_, f, l, _ := runtime.Caller(0)
-	err := fmt.Errorf("%v: %v Error(%w)\n", f, l, e.Err.Error())
+	err := fmt.Errorf("%v: %v Error(%w)\n", f, l, e.Err)
 	return err
 }
 

--- a/cmd/gorilla.go
+++ b/cmd/gorilla.go
@@ -4,7 +4,7 @@ package cmd
 var GorillaRouteBlocks Block = Block{
 	APIVersion: "v1beta",
 	Kind:       "EndpointsBlock",
-	ID:         "io.pavedroard.http.routers.gorilla",
+	ID:         "io.pavedroad.http.routers.gorilla",
 	Family:     "gorilla/mux",
 	Metadata: Metadata{
 		Labels: []string{"gorilla", "router", "http"},
@@ -93,7 +93,7 @@ var GorillaRouteBlocks Block = Block{
 var GorillaMethodBlocks Block = Block{
 	APIVersion: "v1beta",
 	Kind:       "EndpointsBlocks",
-	ID:         "io.pavedroard.http.methods.gorilla",
+	ID:         "io.pavedroad.http.methods.gorilla",
 	Family:     "gorilla/mux",
 	Metadata: Metadata{
 		Labels: []string{"gorilla", "methods", "http"},
@@ -137,7 +137,7 @@ var GorillaMethodBlocks Block = Block{
 		}, {
 			HTTPMethods: []string{"OPTIONS", "TRACE"},
 			Template: TemplateItem{
-				FileName:         "non_keyed_method.tpl",
+				FileName:         "keyed_method.tpl",
 				TemplateFunction: stringFunctionMap(),
 				TemplatePtr:      nil},
 		}, {
@@ -160,6 +160,98 @@ var GorillaMethodBlocks Block = Block{
 		{
 			TemplateVar:         "{{.Namespace}}",
 			SourceInDefinitions: "defs.Project.Kubernetes.Namespace",
+		},
+		{
+			TemplateVar:         "{{.APIVersion}}",
+			SourceInDefinitions: "defs.Project.APIVersion",
+		},
+		{
+			TemplateVar:         "{{.ToCamel}}",
+			SourceInDefinitions: "stringFunctionMap()",
+		},
+		{
+			TemplateVar:         "{{.ToLower}}",
+			SourceInDefinitions: "stringFunctionMap()",
+		},
+		{
+			TemplateVar:         "{{.ToUpper}}",
+			SourceInDefinitions: "stringFunctionMap()",
+		},
+		{
+			TemplateVar:         "{{.ToSnake}}",
+			SourceInDefinitions: "stringFunctionMap()",
+		},
+	},
+}
+
+// GorillaMethodHookBlocks
+var GorillaMethodHookBlocks Block = Block{
+	APIVersion: "v1beta",
+	Kind:       "EndpointsBlocks",
+	ID:         "io.pavedroad.http.methods.gorilla",
+	Family:     "gorilla/mux",
+	Metadata: Metadata{
+		Labels: []string{"gorilla", "methods", "hooks", "http"},
+		Tags:   []string{"http", "methods", "hooks"},
+		Information: BlockInformation{
+			Description: "Gorilla method pre-post processing hooks generator",
+			Title:       "Gorilla method pre-post processing hooks generator",
+			Contact: Contact{
+				Author:       "John Scharber",
+				Organization: "PavedRoad",
+				Email:        "support@pavedroad.io",
+				Website:      "www.pavedroad.io",
+				Support:      "pavedroad-io.slack.com",
+			},
+		},
+	},
+	Language: "go",
+	Imports:  []string{},
+	UsageRights: UsageRights{
+		TermsOfService: "As is",
+		Licenses:       "Apache 2",
+		AccessToken:    "",
+	},
+	BaseDirectory: "/blocks/go/gorilla/",
+	HTTPMappings: []HTTPMethodTemplateMap{
+		{
+			HTTPMethods: []string{"GET", "HEAD", "DELETE", "PUT", "PATCH", "OPTIONS"},
+			Template: TemplateItem{
+				FileName:         "method-keyed-hooks.tpl",
+				TemplateFunction: stringFunctionMap(),
+				TemplatePtr:      nil},
+		},
+		{
+			HTTPMethods: []string{"POST", "TRACE", "CONNECT"},
+			Template: TemplateItem{
+				FileName:         "method-hooks.tpl",
+				TemplateFunction: stringFunctionMap(),
+				TemplatePtr:      nil},
+		},
+		{
+			HTTPMethods: []string{"LIST"},
+			Template: TemplateItem{
+				FileName:         "method-list-hooks.tpl",
+				TemplateFunction: stringFunctionMap(),
+				TemplatePtr:      nil},
+		},
+	},
+	TemplateExports: []ExportedItem{
+		{
+			TemplateVar:         "{{.Method}}",
+			SourceInDefinitions: "defs.Project.Endpoints.Methods",
+		},
+		{
+			TemplateVar:         "{{.EndPointName}}",
+			SourceInDefinitions: "defs.Project.Endpoitns.Name",
+		},
+		{
+			TemplateVar:         "{{.Namespace}}",
+			SourceInDefinitions: "defs.Project.Kubernetes.Namespace",
+		},
+		{
+			TemplateVar:         "{{.NameExported}}",
+			SourceInDefinitions: "defs.Info.Name",
 		},
 		{
 			TemplateVar:         "{{.APIVersion}}",

--- a/cmd/gorilla.go
+++ b/cmd/gorilla.go
@@ -46,9 +46,15 @@ var GorillaRouteBlocks Block = Block{
 				TemplateFunction: stringFunctionMap(),
 				TemplatePtr:      nil},
 		}, {
-			HTTPMethods: []string{"POST", "OPTIONS", "TRACE"},
+			HTTPMethods: []string{"POST", "TRACE"},
 			Template: TemplateItem{
 				FileName:         "non_keyed_route.tpl",
+				TemplateFunction: stringFunctionMap(),
+				TemplatePtr:      nil},
+		}, {
+			HTTPMethods: []string{"OPTIONS"},
+			Template: TemplateItem{
+				FileName:         "options_route.tpl",
 				TemplateFunction: stringFunctionMap(),
 				TemplatePtr:      nil},
 		},

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -7,7 +7,7 @@ import "fmt"
 var PRApplicationLogger Block = Block{
 	APIVersion: "v1beta",
 	Kind:       "CompositeBlock",
-	ID:         "io.pavedroard.core.loggers.application",
+	ID:         "io.pavedroad.core.loggers.application",
 	Family:     "pavedroad/core/logger",
 	Metadata: Metadata{
 		Labels: []string{
@@ -42,7 +42,7 @@ var PRApplicationLogger Block = Block{
 	Imports:  []string{`log "github.com/pavedroad-io/go-core/logger"`},
 	ImportedBlocks: []Block{
 		{
-			ID: "io.pavedroard.core.manifests.kubernetes.kustomize",
+			ID: "io.pavedroad.core.manifests.kubernetes.kustomize",
 			Metadata: Metadata{
 				Labels: []string{
 					"kubernetes",
@@ -55,7 +55,7 @@ var PRApplicationLogger Block = Block{
 			},
 		},
 		{
-			ID: "io.pavedroard.core.manifests.docker.docker-compoase",
+			ID: "io.pavedroad.core.manifests.docker.docker-compoase",
 			Metadata: Metadata{
 				Labels: []string{
 					"docker",

--- a/cmd/sql_to_json.go
+++ b/cmd/sql_to_json.go
@@ -15,7 +15,7 @@ var t Tables
 var SQLToJSONBlock = Block{
 	APIVersion: "v1beta",
 	Kind:       "FunctionBlock",
-	ID:         "http://io.pavedroardr/test/sql/jsonGenerator",
+	ID:         "http://io.pavedroad/test/sql/jsonGenerator",
 	Family:     "pavedroad/test/data/generation",
 	Metadata: Metadata{
 		Labels: []string{
@@ -124,18 +124,19 @@ func createPutData(opt ...interface{}) (result []byte, err error) {
 
 	err = json.Unmarshal(jsonData, &post)
 
-	//	fmt.Println(post)
 	if putData, err := createPostData(opt[0]); err != nil {
 		return nil, err
 	} else {
+		item := def.devineOrder()
 
 		var put map[string]interface{}
 		err = json.Unmarshal(putData, &put)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 		}
 
-		id := strings.ToLower(def.Info.Name) + "uuid"
+		id := strings.ToLower(item.Name) + "uuid"
+		// TODO: add test for id before just assumming it is there
 		b := strings.Replace(string(putData),
 			put[id].(string),
 			post[id].(string), 1)

--- a/cmd/tpl.go
+++ b/cmd/tpl.go
@@ -127,11 +127,14 @@ type tplRouteObject struct {
 	// Namespace in Kubernetes cluster
 	Namespace string `yaml:"namespace"`
 
-	// EndPointName name used in URL as a end point
+	// EndPointName name: used in URL as a end point
 	EndPointName string `yaml:"endPointName"`
 
 	// Method the HTTP method to create a route for
 	Method string `yaml:"method"`
+
+	// NameExported the HTTP method to create a route for
+	NameExported string `yaml:"nameExported"`
 }
 
 //


### PR DESCRIPTION
Use filepath.Join to avoid errors with --blueprints ending with a /
Use root table when generating JSON
Update version number
Update %w in cmd/errors to take error instead of a string